### PR TITLE
Moved selectable setup code to onCreateActionMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ To get the same effect as CHOICE\_MODE\_MULTIPLE\_MODAL, you can either write yo
 
         @Override
         public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
-            getActivity().getMenuInflater().inflate(R.menu.crime_list_item_context, menu);
+            super.onCreateActionMode(actionMode, Menu menu);
+	     getActivity().getMenuInflater().inflate(R.menu.crime_list_item_context, menu);
             return true;
         }
 

--- a/criminalintent-sample/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
+++ b/criminalintent-sample/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
@@ -36,6 +36,7 @@ public class CrimeListFragment extends BaseFragment {
 
         @Override
         public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
+            super.onCreateActionMode(actionMode, menu);
             getActivity().getMenuInflater().inflate(R.menu.crime_list_item_context, menu);
             return true;
         }

--- a/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/ModalMultiSelectorCallback.java
+++ b/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/ModalMultiSelectorCallback.java
@@ -60,6 +60,11 @@ public abstract class ModalMultiSelectorCallback implements ActionMode.Callback 
 
     @Override
     public boolean onPrepareActionMode(ActionMode actionMode, Menu menu) {
+        return false;
+    }
+
+    @Override
+    public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
         if (mClearOnPrepare) {
             mMultiSelector.clearSelections();
         }


### PR DESCRIPTION
Previously, we used `onPrepareActionMode` for multi selector setup code, but this can be unreliable in some cases. I moved this code to `onCreateActionMode`, updated the sample, and added a (now necessary) `super` call to the README.