### PR TITLE
Replaced deprecated getPosition calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ To get the same effect as CHOICE\_MODE\_MULTIPLE\_MODAL, you can either write yo
 
         @Override
         public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
-            getActivity().getMenuInflater().inflate(R.menu.crime_list_item_context, menu);
+            super.onCreateActionMode(actionMode, Menu menu);
+	     getActivity().getMenuInflater().inflate(R.menu.crime_list_item_context, menu);
             return true;
         }
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ If that's still too restrictive, you can implement the SelectableHolder interfac
         void setActivated(boolean activated);
         boolean isActivated();
 
-        int getPosition();
+        int getAdapterPosition();
         long getItemId();
     }
 

--- a/criminalintent-sample/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
+++ b/criminalintent-sample/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
@@ -36,6 +36,7 @@ public class CrimeListFragment extends BaseFragment {
 
         @Override
         public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
+            super.onCreateActionMode(actionMode, menu);
             getActivity().getMenuInflater().inflate(R.menu.crime_list_item_context, menu);
             return true;
         }

--- a/recyclerview-multiselect/build.gradle
+++ b/recyclerview-multiselect/build.gradle
@@ -105,6 +105,6 @@ android.libraryVariants.all { variant ->
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:recyclerview-v7:21.0.3'
     compile 'com.android.support:appcompat-v7:21.0.0'
+    compile 'com.android.support:recyclerview-v7:22.1.1'
 }

--- a/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/ModalMultiSelectorCallback.java
+++ b/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/ModalMultiSelectorCallback.java
@@ -60,6 +60,11 @@ public abstract class ModalMultiSelectorCallback implements ActionMode.Callback 
 
     @Override
     public boolean onPrepareActionMode(ActionMode actionMode, Menu menu) {
+        return false;
+    }
+
+    @Override
+    public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
         if (mClearOnPrepare) {
             mMultiSelector.clearSelections();
         }

--- a/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/MultiSelector.java
+++ b/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/MultiSelector.java
@@ -71,7 +71,7 @@ public class MultiSelector {
      * @param isSelected Whether the item should be selected.
      */
     public void setSelected(SelectableHolder holder, boolean isSelected) {
-        setSelected(holder.getPosition(), holder.getItemId(), isSelected);
+        setSelected(holder.getAdapterPosition(), holder.getItemId(), isSelected);
     }
 
     /**
@@ -152,7 +152,7 @@ public class MultiSelector {
      * @return True if {@link #isSelectable()} and selection was toggled for this item.
      */
     public boolean tapSelection(SelectableHolder holder) {
-        return tapSelection(holder.getPosition(), holder.getItemId());
+        return tapSelection(holder.getAdapterPosition(), holder.getItemId());
     }
 
     /**
@@ -201,7 +201,7 @@ public class MultiSelector {
         }
         holder.setSelectable(mIsSelectable);
 
-        boolean isActivated = mSelections.get(holder.getPosition());
+        boolean isActivated = mSelections.get(holder.getAdapterPosition());
         holder.setActivated(isActivated);
     }
 

--- a/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/MultiSelectorBindingHolder.java
+++ b/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/MultiSelectorBindingHolder.java
@@ -20,6 +20,6 @@ public abstract class MultiSelectorBindingHolder extends RebindReportingHolder i
 
     @Override
     protected void onRebind() {
-        mMultiSelector.bindHolder(this, getPosition(), getItemId());
+        mMultiSelector.bindHolder(this, getAdapterPosition(), getItemId());
     }
 }

--- a/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/SelectableHolder.java
+++ b/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/SelectableHolder.java
@@ -40,7 +40,7 @@ public interface SelectableHolder {
      *
      * @return Position this holder is currently bound to.
      */
-    int getPosition();
+    int getAdapterPosition();
 
     /**
      * <p>Return the item id this item is currently bound to.

--- a/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/WeakHolderTracker.java
+++ b/recyclerview-multiselect/src/main/java/com/bignerdranch/android/multiselector/WeakHolderTracker.java
@@ -24,7 +24,7 @@ class WeakHolderTracker {
         }
 
         SelectableHolder holder = holderRef.get();
-        if (holder == null || holder.getPosition() != position) {
+        if (holder == null || holder.getAdapterPosition() != position) {
             mHoldersByPosition.remove(position);
             return null;
         }


### PR DESCRIPTION
Relies on #6.

Upgraded to latest version of `RecyclerView` and replaced deprecated `getPosition` calls with `getAdapterPosition`.