### PR TITLE
Fixed broken link to Javadocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To import, add the following line to your build.gradle:
 
     compile 'com.bignerdranch.android:recyclerview-multiselect:+'
 
-You can find Javadocs [here](javadocs/).
+You can find Javadocs [here](http://bignerdranch.github.io/recyclerview-multiselect/javadocs/).
 
 ## Basics
 


### PR DESCRIPTION
Resolves #12.

Old link was 404ing.